### PR TITLE
Add support for Cordova 9

### DIFF
--- a/hooks/before_prepare/setVersionOnApp.js
+++ b/hooks/before_prepare/setVersionOnApp.js
@@ -2,8 +2,8 @@
 module.exports = function(context) {
 
 	var fs = require('q-io/fs');
-	var q = context.requireCordovaModule('q');
-	var semver = context.requireCordovaModule('semver');
+	var q = require('q');
+	var semver = require('semver');
 
 	var ConfigParser = context.requireCordovaModule('cordova-lib').configparser;
 	var cfg = new ConfigParser(fs.join(context.opts.projectRoot, 'config.xml'));

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "homepage": "https://github.com/Binarypark/cordova_app_version_plugin#readme",
   "dependencies": {
-    "q-io": "~1.13.2"
+    "q-io": "~1.13.2",
+    "semver": "~5.7.1"
   }
 }


### PR DESCRIPTION
The newest version of Cordova removes the modules `q-io` and `semver` from
its core. To have the plugin still work, we therefore need to require
those as regular modules instead of internal Cordova modules.